### PR TITLE
CI : Add Murray as reviewer for automatic documentation updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -39,4 +39,4 @@ jobs:
         delete-branch: true
         reviewers: |
           johnhaddon
-          danieldresser-ie
+          murraystevenson


### PR DESCRIPTION
@murraystevenson, this means you will receive review requests for pull requests like these : https://github.com/GafferHQ/documentation/pull/65. They are created automatically when we release a new Gaffer version, allowing us to easily pull the latest docs over in to the website.