### PR TITLE
Update workflow : Avoid `distutils`

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Update
       id: update
       run: |
-        ./update.py --set-outputs 1
+        ./update.py --set-outputs
 
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3

--- a/update.py
+++ b/update.py
@@ -3,7 +3,6 @@
 import github
 
 import argparse
-import distutils.util
 import glob
 import os
 import shutil
@@ -22,8 +21,8 @@ parser.add_argument(
 parser.add_argument(
 	"--set-outputs",
 	dest = "setOutputs",
-	type = distutils.util.strtobool,
-	default = "0",
+	default = False,
+	action = "store_true",
 	help = "Echo the outputs needed by `.github/workflows/update.yml`."
 )
 args = parser.parse_args()


### PR DESCRIPTION
This has gone in Python 3.12, and Python 3.12 has recently become the default on the GitHub runners.