### PR TITLE
Update from gcc9 package variants

### DIFF
--- a/update.py
+++ b/update.py
@@ -69,7 +69,7 @@ if latestReleaseVersion <= latestDocVersion :
 
 # Otherwise we should download the release and add the docs to this repo
 
-packageName = "gaffer-{}-linux".format( __versionToString( latestReleaseVersion ) )
+packageName = "gaffer-{}-linux-gcc9".format( __versionToString( latestReleaseVersion ) )
 
 assetToDownload = None
 assets = latestRelease.get_assets()


### PR DESCRIPTION
As we are producing dual builds of Gaffer 1.4, use the documentation built from the gcc9 container for consistency with the Gaffer 1.3 documentation builds.