### PR TITLE
CI push fixes

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -36,6 +36,7 @@ jobs:
     - name: Create Pull Request
       uses: peter-evans/create-pull-request@v3
       with:
+        base: gh-pages
         commit-message: "${{steps.update.outputs.title}}\n\n${{steps.update.outputs.body}}"
         title: ${{steps.update.outputs.title}}
         body: ${{steps.update.outputs.body}}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -2,6 +2,8 @@ name: Update from Releases
 
 on:
   push:
+    branches:
+      - gh-pages
   schedule:
      # At the end of every day
      - cron: 0 0 * * *


### PR DESCRIPTION
Attempts to avoid the potential CI snafu we ran into earlier where pull requests can trigger legitimate looking "Update from Gaffer x.x.x.x" PRs that target their branch rather than `gh-pages`...