### PR TITLE
Update from gcc11 package variants

### DIFF
--- a/update.py
+++ b/update.py
@@ -69,7 +69,7 @@ if latestReleaseVersion <= latestDocVersion :
 
 # Otherwise we should download the release and add the docs to this repo
 
-packageName = "gaffer-{}-linux-gcc9".format( __versionToString( latestReleaseVersion ) )
+packageName = "gaffer-{}-linux-gcc11".format( __versionToString( latestReleaseVersion ) )
 
 assetToDownload = None
 assets = latestRelease.get_assets()


### PR DESCRIPTION
With the 1.5.0.0 release we no longer produce `linux-gcc9` builds, so we now take the documentation from the `linux-gcc11` packages.