### PR TITLE
CI : Run on Ubuntu 24.04

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,7 +11,7 @@ jobs:
 
   Update:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
 


### PR DESCRIPTION
Support for Ubuntu 20.04 is being removed by GitHub and 24.04 is now the latest available.